### PR TITLE
Allow using customized error handlers

### DIFF
--- a/src/CompileAttribute.ts
+++ b/src/CompileAttribute.ts
@@ -41,6 +41,9 @@ export class CompileAttribute implements OnInit, OnChanges{
     @Input('p3x-compile-ctx')
     context:  any;
 
+    @Input('p3x-error-handler')
+    errorHandler: (ex: any) => void = console.error;
+
     dynamicComponent: any;
     dynamicModule: NgModuleFactory<any> | any;
 
@@ -69,7 +72,7 @@ export class CompileAttribute implements OnInit, OnChanges{
             this.dynamicModule = this.compiler.compileModuleSync(this.createComponentModule(this.dynamicComponent));
 //            cache[cacheKey] = this.dynamicComponent;
         } catch (e) {
-            console.error(e);
+            this.errorHandler(e);
         }
         /*
         await this.service.compile({


### PR DESCRIPTION
We'd like to provide our own error handler in order to avoid logging to the browser console, would you kindly merge our changes? It should work transparently for other users without changing behaviour.

Many thanks in advance.